### PR TITLE
Fix docker build and run stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,44 +21,44 @@ COPY ./ ./
 FROM hadolint/hadolint:v1 AS lint_docker
 WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/ .
-CMD ["hadolint", "Dockerfile"]
+RUN ["hadolint", "Dockerfile"]
 
 ## Lint git
 FROM builder AS lint_git
-CMD ["gitlint", "--commits", "HEAD"]
+RUN ["gitlint", "--commits", "HEAD"]
 
 ## Lint Makefile
 # https://hub.docker.com/r/cytopia/checkmake/tags
 FROM cytopia/checkmake:0.1.0 AS lint_make
 WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/ .
-ENTRYPOINT ["checkmake", "Makefile"]
+RUN ["checkmake", "Makefile"]
 
 ## Lint Python
 FROM builder AS lint_python
-CMD find . -type f -name '*.py' -exec pylint -j 0 {} +
+RUN find . -type f -name '*.py' -exec pylint -j 0 {} +
 
 ## Lint yaml
 FROM builder AS lint_yaml
-CMD find . -type f \( -name '*.yml' -o -name '*.yaml' \) -exec yamllint {} +
+RUN find . -type f \( -name '*.yml' -o -name '*.yaml' \) -exec yamllint {} +
 
 ## Type Annotations Linter
 FROM builder AS lint_types
 ARG ARG_VENDOR
-CMD find "${ARG_VENDOR}" -type f -name '*.py' -exec mypy {} +
+RUN find "${ARG_VENDOR}" -type f -name '*.py' -exec mypy {} +
 
 ## Complexity Linter
 FROM builder AS lint_complexity
 ARG ARG_VENDOR
-CMD find "${ARG_VENDOR}" -type f -name '*.py' -exec xenon --max-absolute B {} +
+RUN find "${ARG_VENDOR}" -type f -name '*.py' -exec xenon --max-absolute B {} +
 
 ## Unit Tests
 FROM builder AS test_unit
-CMD coverage run -m unittest discover -s tests -p "test_*.py"
+RUN coverage run -m unittest discover -s tests -p "test_*.py"
 
 ## Security Tests
 FROM builder AS test_security
-CMD find . -type f -name '*.py' -exec bandit {} + && \
+RUN find . -type f -name '*.py' -exec bandit {} + && \
   trufflehog --regex --entropy=False file:///usr/src/app/ --exclude_paths .truffleHog-exclude.txt
 
 ## easy_sast

--- a/reports/bandit_report.json
+++ b/reports/bandit_report.json
@@ -1,6 +1,6 @@
 {
   "errors": [],
-  "generated_at": "2020-01-02T15:41:09Z",
+  "generated_at": "2020-01-02T18:38:30Z",
   "metrics": {
     "./main.py": {
       "CONFIDENCE.HIGH": 0.0,

--- a/reports/htmlcov/index.html
+++ b/reports/htmlcov/index.html
@@ -138,7 +138,7 @@
     <div class="content">
         <p>
             <a class="nav" href="https://coverage.readthedocs.io">coverage.py v5.0.1</a>,
-            created at 2020-01-02 15:40
+            created at 2020-01-02 18:38
         </p>
     </div>
 </div>


### PR DESCRIPTION
# Contributor Comments
Using RUN is required to exit non-zero during both a `docker build`
command with `--target` stage not defined, and with a `docker run` that
uses an already-built image (See `Makefile` and `Dockerfile`)

Also, move to a cleaner approach to sharing information from arguments
across a multi-stage docker build, based on
https://github.com/moby/moby/issues/37345#issuecomment-400250849

## Pull Request Checklist
Thank you for submitting a contribution to `easy_sast`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Keep our reports up-to-date by commiting the output of `make report`
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)